### PR TITLE
README.md add link to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ Join the community → [t.me/AKSLabs](https://t.me/AKSLabs)
 - 👨‍💻 **Contribute:** Fork and submit pull requests
 - ⭐ **Show support:** Star the repository!
 
+Please help to translate using [Weblate](https://toolate.othing.xyz/projects/cloudgallery/).
+
+<a href="https://toolate.othing.xyz/projects/cloudgallery/">
+<img src="https://toolate.othing.xyz/widget/pixelscreenshots/svg-badge.svg" alt="Translation status" />
+</a>
+
 ---
 
 ## 🙏 **Credits**


### PR DESCRIPTION
To make it easier to translate it would be great to integrate a translation service.
The https://toolate.othing.xyz/ is an instance of the [Weblate](https://weblate.org/), it has no pre-moderation, it can send a PR with translations. It's used by many of the F-Droid apps.

I created a translation project on the Toolate https://toolate.othing.xyz/projects/cloudgallery/
and also made a testing translations and it sent you a PR #15.

If you are fine with the solution then please merge the PR that adds the Toolate link to the README to help users to find it. Also if you wish I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).

Thank you for the app!